### PR TITLE
Add translation toggle for chat and journal

### DIFF
--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -70,6 +70,7 @@ namespace ClassicUO.Configuration
         public bool ForceUnicodeJournal { get; set; }
         public bool IgnoreAllianceMessages { get; set; }
         public bool IgnoreGuildMessages { get; set; }
+        public bool TranslateIncomingMessages { get; set; }
 
         // hues
         public ushort SpeechHue { get; set; } = 0x02B2;

--- a/src/ClassicUO.Client/Game/Managers/TranslationManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/TranslationManager.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text.Json;
+using ClassicUO.Configuration;
+
+namespace ClassicUO.Game.Managers
+{
+    internal static class TranslationManager
+    {
+        private static readonly Dictionary<string, string> _dictionary = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            {"hello", "hola"},
+            {"world", "mundo"},
+            {"yes", "sí"},
+            {"no", "no"}
+        };
+
+        private static readonly HttpClient _http = new HttpClient();
+
+        public static string Translate(string text)
+        {
+            if (string.IsNullOrEmpty(text))
+            {
+                return text;
+            }
+
+            // First try local dictionary
+            if (_dictionary.TryGetValue(text, out string translated))
+            {
+                return translated;
+            }
+
+            // Fallback to external API if possible
+            try
+            {
+                var url = $"https://api.mymemory.translated.net/get?q={Uri.EscapeDataString(text)}&langpair=en|es";
+                string json = _http.GetStringAsync(url).GetAwaiter().GetResult();
+                using JsonDocument doc = JsonDocument.Parse(json);
+                if (doc.RootElement.TryGetProperty("responseData", out JsonElement rd) &&
+                    rd.TryGetProperty("translatedText", out JsonElement tt))
+                {
+                    translated = tt.GetString();
+                    if (!string.IsNullOrEmpty(translated))
+                    {
+                        return translated;
+                    }
+                }
+            }
+            catch
+            {
+                // ignored - fallback to original text
+            }
+
+            return text;
+        }
+    }
+}
+

--- a/src/ClassicUO.Client/Game/UI/Gumps/JournalGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/JournalGump.cs
@@ -279,6 +279,11 @@ namespace ClassicUO.Game.UI.Gumps
                 text = entry.Text;
             }
 
+            if (ProfileManager.CurrentProfile.TranslateIncomingMessages)
+            {
+                text = TranslationManager.Translate(text);
+            }
+
             _journalEntries.AddEntry
             (
                 text,

--- a/src/ClassicUO.Client/Game/UI/Gumps/OptionsGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/OptionsGump.cs
@@ -121,7 +121,7 @@ namespace ClassicUO.Game.UI.Gumps
         private Checkbox _showHouseContent;
         private Checkbox _showInfoBar;
         private Checkbox _ignoreAllianceMessages;
-        private Checkbox _ignoreGuildMessages, _useAlternateJournal, _partyMessagesOverhead;
+        private Checkbox _ignoreGuildMessages, _useAlternateJournal, _partyMessagesOverhead, _translateMessages;
 
         // general
         private HSliderBar _sliderFPS, _circleOfTranspRadius;
@@ -2504,6 +2504,17 @@ namespace ClassicUO.Game.UI.Gumps
 
             startY += _ignoreAllianceMessages.Height + 2;
 
+            _translateMessages = AddCheckBox
+            (
+                rightArea,
+                "Translate messages to Spanish",
+                _currentProfile.TranslateIncomingMessages,
+                startX,
+                startY
+            );
+
+            startY += _translateMessages.Height + 2;
+
             _useAlternateJournal = AddCheckBox
             (
                 rightArea,
@@ -4001,6 +4012,7 @@ namespace ClassicUO.Game.UI.Gumps
             _currentProfile.HideChatGradient = _hideChatGradient.IsChecked;
             _currentProfile.IgnoreGuildMessages = _ignoreGuildMessages.IsChecked;
             _currentProfile.IgnoreAllianceMessages = _ignoreAllianceMessages.IsChecked;
+            _currentProfile.TranslateIncomingMessages = _translateMessages.IsChecked;
             _currentProfile.UseAlternateJournal = _useAlternateJournal.IsChecked;
 
             // fonts

--- a/src/ClassicUO.Client/Game/UI/Gumps/SystemChatControl.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/SystemChatControl.cs
@@ -325,6 +325,11 @@ namespace ClassicUO.Game.UI.Gumps
                 _textEntries.Remove(lineToRemove);
             }
 
+            if (ProfileManager.CurrentProfile.TranslateIncomingMessages)
+            {
+                text = TranslationManager.Translate(text);
+            }
+
             _textEntries.AddLast(new ChatLineTime(text, font, isunicode, hue));
         }
 


### PR DESCRIPTION
## Summary
- translate incoming messages via new `TranslationManager`
- allow optional Spanish translation for system chat and journal entries
- expose automatic translation checkbox in Options

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a7a5014354832e940cba8bd9d3e7b5